### PR TITLE
feat(SubmitError): add component

### DIFF
--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@jengaui/content": "workspace:0.2.0",
+    "@jengaui/alert": "workspace:0.2.0",
     "@jengaui/layout": "workspace:0.2.0",
     "@jengaui/providers": "workspace:0.2.0",
     "@jengaui/tooltip": "workspace:0.2.0",

--- a/packages/form/src/form/Form.tsx
+++ b/packages/form/src/form/Form.tsx
@@ -3,9 +3,11 @@ import {
   createContext,
   FormHTMLAttributes,
   forwardRef,
+  ReactNode,
   useContext,
   useEffect,
   useRef,
+  useState,
 } from 'react';
 import { DOMRef } from '@react-types/shared';
 
@@ -103,6 +105,7 @@ function Form<T extends FieldTypes>(
     ...otherProps
   } = props;
   const firstRunRef = useRef(true);
+  const [submitError, setSubmitError] = useState<ReactNode>(null);
 
   ref = useCombinedRefs(ref);
 
@@ -128,6 +131,8 @@ function Form<T extends FieldTypes>(
 
       if (!form || form.isSubmitting) return;
 
+      setSubmitError(null);
+      form.submitError = null;
       form.setSubmitting(true);
 
       try {
@@ -136,10 +141,13 @@ function Form<T extends FieldTypes>(
         await onSubmit?.(form.getFormData());
       } catch (e) {
         await timeout();
+
         if (e instanceof Error) {
           throw e;
         }
         // errors are shown
+        setSubmitError(e as ReactNode);
+        form.submitError = e as ReactNode;
         // transfer errors to the callback
         onSubmitFailed?.(e);
       } finally {
@@ -171,6 +179,7 @@ function Form<T extends FieldTypes>(
     validateTrigger,
     requiredMark,
     form,
+    submitError,
     idPrefix: name,
   };
 

--- a/packages/form/src/form/SubmitError.tsx
+++ b/packages/form/src/form/SubmitError.tsx
@@ -1,0 +1,26 @@
+import { ReactNode, useContext } from 'react';
+
+import { Alert, JengaAlertProps } from '@jengaui/alert';
+
+import { FormContext } from './Form';
+
+type SubmitErrorProps = {
+  submitError?: ReactNode;
+};
+
+/**
+ * An alert that shows a form error message received from the onSubmit callback.
+ */
+export function SubmitError(props: JengaAlertProps) {
+  const { submitError } = useContext(FormContext) as SubmitErrorProps;
+
+  if (!submitError) {
+    return null;
+  }
+
+  return (
+    <Alert theme="danger" {...props}>
+      {submitError}
+    </Alert>
+  );
+}

--- a/packages/form/src/form/index.ts
+++ b/packages/form/src/form/index.ts
@@ -1,16 +1,21 @@
+import { JengaAlertProps } from '@jengaui/alert';
+
 import { Field } from './Field';
+import { SubmitError } from './SubmitError';
 import { useForm } from './useForm';
 import { useFormProps, FormContext, Form as _Form } from './Form';
 
 const Form = Object.assign(
   _Form as typeof _Form & {
     Item: typeof Field;
+    SubmitError: typeof SubmitError;
     useForm: typeof useForm;
   },
-  { Item: Field, useForm },
+  { Item: Field, useForm, SubmitError },
 );
 
-export { useFormProps, Form, Field, useForm, FormContext };
+export { useFormProps, Form, Field, useForm, FormContext, SubmitError };
 export type { JengaFormProps } from './Form';
 export type { JengaFormInstance } from './useForm';
 export type { FieldTypes, Fields } from './types';
+export type { JengaAlertProps as JengaSubmitErrorProps };

--- a/packages/form/src/form/useForm.tsx
+++ b/packages/form/src/form/useForm.tsx
@@ -34,6 +34,7 @@ export class JengaFormInstance<
   private fields: TFormData = {} as TFormData;
   public ref = {};
   public isSubmitting = false;
+  public submitError: ReactNode = null;
 
   public onValuesChange: (data: T) => void | Promise<void> = () => {};
   public onSubmit: (data: T) => void | Promise<void> = () => {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,6 +736,7 @@ importers:
   packages/form:
     specifiers:
       '@ant-design/icons': ^4.7.0
+      '@jengaui/alert': workspace:0.2.0
       '@jengaui/content': workspace:0.2.0
       '@jengaui/layout': workspace:0.2.0
       '@jengaui/providers': workspace:0.2.0
@@ -756,6 +757,7 @@ importers:
       typescript: ^4.8.4
       valid-url: ^1.0.9
     dependencies:
+      '@jengaui/alert': link:../alert
       '@jengaui/content': link:../content
       '@jengaui/layout': link:../layout
       '@jengaui/providers': link:../providers
@@ -4010,7 +4012,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -4075,7 +4077,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       jest-mock: 27.5.1
     dev: true
 
@@ -4092,7 +4094,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -4121,7 +4123,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -7378,20 +7380,20 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.11.65
+      '@types/node': 18.11.0
     dev: true
 
   /@types/glob/8.0.0:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.11.65
+      '@types/node': 18.11.0
     dev: true
 
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
     dev: true
 
   /@types/hast/2.3.4:
@@ -7469,7 +7471,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 16.11.65
+      '@types/node': 18.11.0
       form-data: 3.0.1
     dev: true
 
@@ -7617,7 +7619,7 @@ packages:
   /@types/webpack-sources/3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 16.11.65
+      '@types/node': 18.11.0
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: true
@@ -7625,7 +7627,7 @@ packages:
   /@types/webpack/4.41.33:
     resolution: {integrity: sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==}
     dependencies:
-      '@types/node': 16.11.65
+      '@types/node': 18.11.0
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.17.0
       '@types/webpack-sources': 3.2.0
@@ -13102,7 +13104,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -13237,7 +13239,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -13255,7 +13257,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -13299,7 +13301,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       anymatch: 3.1.2
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -13321,7 +13323,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -13462,7 +13464,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.10
@@ -13527,7 +13529,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       graceful-fs: 4.2.10
     dev: true
 
@@ -13588,7 +13590,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       chalk: 4.1.2
       ci-info: 3.5.0
       graceful-fs: 4.2.10
@@ -13625,7 +13627,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.7.14
+      '@types/node': 18.11.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -13645,7 +13647,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.11.65
+      '@types/node': 18.11.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -15863,7 +15865,7 @@ packages:
     dependencies:
       object-assign: 4.1.1
       react: 17.0.2
-      react-is: 17.0.2
+      react-is: 18.2.0
     dev: true
 
   /react-test-renderer/17.0.2_react@17.0.2:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## Description

Add `SubmitError`

## Current behavior (updates)

N/A

## New behavior

- Add `SubmitError` component to display the error that throws `onSubmit` callback.
- Allow to manually visualize a submit error.

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Jenga UI users. -->

## Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Pipeline is passed.
- [ ] Tests are added (including unit tests and stories in the storybook).
- [ ] Tests are passed successfully.
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works.

## Additional Information
